### PR TITLE
feat: Enhance DirectionStack component with additional justifyContent…

### DIFF
--- a/common/components/Layout/Stacks/DirectionStack.tsx
+++ b/common/components/Layout/Stacks/DirectionStack.tsx
@@ -4,8 +4,9 @@ import { Stack } from '@mui/material';
 
 type DirectionStackProps = {
     spacing?: number;
-    justifyContent?: 'flex-start' | 'center' | 'flex-end';
+    justifyContent?: 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly';
     alignItems?: 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline';
+    style?: React.CSSProperties;
     children: React.ReactNode;
 };
 
@@ -13,6 +14,7 @@ export default function DirectionStack({
     spacing = 2,
     justifyContent = 'center',
     alignItems = 'center',
+    style,
     children,
 }: DirectionStackProps) {
     return (
@@ -21,6 +23,7 @@ export default function DirectionStack({
             spacing={spacing}
             justifyContent={justifyContent}
             alignItems={alignItems}
+            style={style}
         >
             {children}
         </Stack>

--- a/common/components/data/icon/SportsEsports.tsx
+++ b/common/components/data/icon/SportsEsports.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import SportsEsports from '@mui/icons-material/SportsEsports';
+
+export default SportsEsports;


### PR DESCRIPTION
This pull request makes enhancements to the UI components by improving the flexibility of the `DirectionStack` component and adding a new icon export for client-side usage. The most important changes are grouped below:

**DirectionStack component improvements:**

* Expanded the `justifyContent` prop in `DirectionStack.tsx` to support additional values: `'space-between'`, `'space-around'`, and `'space-evenly'`. This allows for more layout options when arranging child components.
* Added an optional `style` prop to `DirectionStack.tsx`, enabling custom inline styling for the component.
* Passed the new `style` prop down to the underlying `Stack` component, ensuring that custom styles are applied.

**Icon export for client-side rendering:**

* Added a new file `SportsEsports.tsx` that exports the `SportsEsports` icon from MUI, marked for client-side usage with `'use client'`. This makes the icon available for use in client-rendered components.… options and style prop; add SportsEsports icon component