### PR TITLE
Prevent table cell wrapping and enable horizontal scroll in BasicTable

### DIFF
--- a/common/components/data/table/BasicTable.tsx
+++ b/common/components/data/table/BasicTable.tsx
@@ -68,8 +68,8 @@ function BasicTable<T>({
 
   return (
     <Paper>
-      <TableContainer>
-        <Table stickyHeader aria-label="sticky table">
+      <TableContainer style={{ overflowX: 'auto' }}>
+        <Table stickyHeader aria-label="sticky table" style={{ whiteSpace: 'nowrap' }}>
           <TableHead>
             <TableRow>
               {columns.map((column) => (


### PR DESCRIPTION
Implement horizontal scrolling for the BasicTable by preventing cell wrapping, ensuring better visibility of content without overflow issues.