### PR TITLE
v1.10.0

### DIFF
--- a/common/components/feedback/dialog/BasicDialog.tsx
+++ b/common/components/feedback/dialog/BasicDialog.tsx
@@ -31,6 +31,11 @@ export interface BasicDialogProps {
    * If true, clicking outside the dialog will not close it.
    */
   disableBackdropClick?: boolean;
+
+  /**
+   * Props to pass to the Dialog's Paper component.
+   */
+  paperProps?: DialogProps['PaperProps'];
 };
 
 export default function BasicDialog({
@@ -43,6 +48,7 @@ export default function BasicDialog({
   closeText = 'Cancel',
   disableClose = false,
   disableBackdropClick = false,
+  paperProps,
 }: BasicDialogProps) {
   const handleClose: DialogProps['onClose'] = (_, reason) => {
     if (!disableBackdropClick) {
@@ -59,7 +65,7 @@ export default function BasicDialog({
   return (
     <LoadingContent>
       {(loading, runWithLoading) => (
-        <Dialog open={open} onClose={handleClose} aria-labelledby="basic-dialog-title">
+        <Dialog open={open} onClose={handleClose} aria-labelledby="basic-dialog-title" PaperProps={paperProps}>
           <DialogTitle id="basic-dialog-title">{title}</DialogTitle>
           <DialogContent dividers>{children(loading, runWithLoading)}</DialogContent>
           <DialogActions>


### PR DESCRIPTION
This pull request adds support for customizing the Paper component in the `BasicDialog` by allowing `PaperProps` to be passed through its props. This enhancement makes it easier to control the appearance and behavior of dialogs.

Dialog customization:

* Added a new `paperProps` prop to the `BasicDialogProps` interface, allowing consumers to pass custom props to the Dialog's Paper component.
* Updated the `BasicDialog` component to accept and forward the `paperProps` to the underlying `Dialog` via its `PaperProps` prop. [[1]](diffhunk://#diff-c492b630732d03aee56deacc85f36f8431f37e23947028341d1233f787677475R51) [[2]](diffhunk://#diff-c492b630732d03aee56deacc85f36f8431f37e23947028341d1233f787677475L62-R68)